### PR TITLE
reduce graph complexity

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "classnames": "^2.2.5",
+    "cytoscape-expand-collapse": "^3.0.3",
     "fetch-ponyfill": "^4.0.0",
     "file-saver": "^1.3.3",
     "http-server": "^0.9.0",


### PR DESCRIPTION
- use bilkent expand collapse
- collapse nodes by default
- remove floating non-compound nodes
- remove floating child nodes in compartment nodes
- bind click event to renderer to expand/collapse complex nodes

