### PR TITLE
Lucene fix

### DIFF
--- a/js/search/components/SearchBar.jsx
+++ b/js/search/components/SearchBar.jsx
@@ -34,8 +34,7 @@ export class SearchBar extends React.Component {
 				lt: 250,
 				gt: 3,
 				type: "Pathway",
-				enhance: this.props.query.enhance,
-				escape: this.props.query.escape
+				enhance: this.props.query.enhance
 			});
 		}
 	}

--- a/js/search/components/SearchOptions.jsx
+++ b/js/search/components/SearchOptions.jsx
@@ -15,8 +15,7 @@ const filterPropList = [
 	"datasource",
 	"lt",
 	"gt",
-	"enhance",
-	"escape"
+	"enhance"
 ]
 
 // SearchOptions
@@ -33,8 +32,7 @@ export class SearchOptions extends React.Component {
 			datasourceRef: [],
 			lt: this.props.query.lt || "",
 			gt: this.props.query.gt || "",
-			enhance: this.props.query.enhance || "",
-			escape: this.props.query.escape || ""
+			enhance: this.props.query.enhance || ""
 		};
 
 		Promise.all([
@@ -144,17 +142,6 @@ export class SearchOptions extends React.Component {
 					</div>
 					<HelpBlock>
 						Toggles advanced search query parsing; a system which attempts to refine search relevance, on or off. More information on what it does and how it works is available in the FAQ.
-					</HelpBlock>
-				</FormGroup>
-				<FormGroup>
-					<ControlLabel>
-						Lucene Escape Input:
-					</ControlLabel>
-					<div onClick={() => this.updateFilter("escape", this.state.escape !== "false" ? "false" : "true")}>
-						<Toggle checked={this.state.escape !== "false"} onChange={() => {/* No op */}}/>
-					</div>
-					<HelpBlock>
-						Escapes user input to ensure that any Lucene special characters do not interfere with search. Overridden when search enhance is enabled. Recommend leaving enabled unless you intend to enter Lucene manually.
 					</HelpBlock>
 				</FormGroup>
 			</div>

--- a/js/search/helpers/queryProcessing.js
+++ b/js/search/helpers/queryProcessing.js
@@ -59,7 +59,7 @@ export let queryProcessing = (query, failureCount = 0) => { // Pass in all query
 					}
 					// When using enhanced search Lucene is always escaped
 					word = escapeLucene(word);
-					return (isSymbol ? word : "name:" + word);
+					return (isSymbol ? word : "name:" + "*" + word + "*" );
 				})
 				.reduce((acc, val, index) => {
 					return acc + (index !== 0 ? (failureCount > 0 ? " " : " AND ") : "") + val;

--- a/js/search/helpers/queryProcessing.js
+++ b/js/search/helpers/queryProcessing.js
@@ -8,6 +8,10 @@ var checkList = [
 	"keggpathway"
 ];
 
+var nameBlacklist = [
+	"CELL"
+];
+
 // var hgncUrl = "http://www.genenames.org/cgi-bin/download?col=gd_app_sym&col=gd_prev_sym&status=Approved&status_opt=2&where=&order_by=gd_app_sym_sort&format=text&limit=&submit=submit"; // URL of hgncSymbols.txt data
 
 let parseFile = text => {
@@ -16,7 +20,8 @@ let parseFile = text => {
 
 	return textNoHeader
 	.split(/[\s,]+/) // Split file string by whitespace (spaces, tabs, newlines) and commas
-	.filter(symbol => symbol); // Check for and remove any empty strings
+	.filter(symbol => symbol) // Check for and remove any empty strings
+	.filter(symbol => nameBlacklist.indexOf(symbol) == -1); // Filter out ridiculous names
 };
 
 let hgncData = fetch("hgncSymbols.txt", {method: 'get', mode: 'no-cors'})
@@ -61,7 +66,6 @@ export let queryProcessing = (query, failureCount = 0) => { // Pass in all query
 					return (isSymbol ? word : "name:" + "*" + word + "*" );
 				})
 				.reduce((acc, val, index) => {
-					console.log(acc + (index !== 0 ? (failureCount > 0 ? " " : " AND ") : "") + val);
 					return acc + (index !== 0 ? (failureCount > 0 ? " " : " AND ") : "") + val;
 				})
 			);

--- a/js/search/helpers/queryProcessing.js
+++ b/js/search/helpers/queryProcessing.js
@@ -33,7 +33,6 @@ export let queryProcessing = (query, failureCount = 0) => { // Pass in all query
 		return Promise.resolve(null);
 	}
 
-	var escape = query.escape !== "false";
 	var enhance = query.enhance !== "false";
 	var output = "";
 
@@ -62,11 +61,12 @@ export let queryProcessing = (query, failureCount = 0) => { // Pass in all query
 					return (isSymbol ? word : "name:" + "*" + word + "*" );
 				})
 				.reduce((acc, val, index) => {
+					console.log(acc + (index !== 0 ? (failureCount > 0 ? " " : " AND ") : "") + val);
 					return acc + (index !== 0 ? (failureCount > 0 ? " " : " AND ") : "") + val;
 				})
 			);
 	}
 	else {
-			return Promise.resolve(escape ? escapeLucene(words) : words);
+			return Promise.resolve(words);
 	}
 }


### PR DESCRIPTION
1. Lucene character escaping performed implicitly in enhanced search only 
2. Added blacklist for absurd HGNC alternative names (e.g. CELL)
3. Modified name index field values to be 'fuzzy'   